### PR TITLE
(refactor) Jumbotron inner elements style change

### DIFF
--- a/client/components/Jumbotron/LeftCloud.jsx
+++ b/client/components/Jumbotron/LeftCloud.jsx
@@ -6,7 +6,7 @@ import style from './style';
 
 const LeftCloud = (props) => (
 
-  <div style={applyStyles(style.leftCloud, {marginLeft: `${-(props.yOffset * 1.11)}px`})}>
+  <div style={applyStyles(style.leftCloud, {left: `${-(props.yOffset * 1.11)}px`})}>
     <img src='https://s3-us-west-1.amazonaws.com/cos-bytes.com/leftCloud.png'/>
   </div>
 

--- a/client/components/Jumbotron/RightCloud.jsx
+++ b/client/components/Jumbotron/RightCloud.jsx
@@ -6,7 +6,7 @@ import style from './style';
 
 const RightCloud = (props) => (
 
-  <div style={applyStyles(style.rightCloud, {marginRight: `${-(props.yOffset * 1.11)}px`})}>
+  <div style={applyStyles(style.rightCloud, {right: `${-(props.yOffset * 1.11)}px`})}>
     <img src='https://s3-us-west-1.amazonaws.com/cos-bytes.com/rightCloud.png'/>
   </div>
 

--- a/client/components/Jumbotron/TextScroller.jsx
+++ b/client/components/Jumbotron/TextScroller.jsx
@@ -38,7 +38,7 @@ class TextScroller extends React.Component {
 
       <div style={{
         height: '30px',
-        marginBottom: '-400px',
+        // marginBottom: '-400px',
         color: `rgba(41, 67, 78, 1.0)`
       }}>
         {messages[currentMessageIndex]}

--- a/client/components/Jumbotron/style.js
+++ b/client/components/Jumbotron/style.js
@@ -4,7 +4,7 @@ module.exports.body = {
   overflow: 'hidden',
   flexDirection: 'column',
   alignItems:'center',
-  justifyContent: 'space-evenly',
+  justifyContent: 'center',
   height: '500px',
   width: '100%',
   background: `linear-gradient(to bottom, #ffffff 6%, #b3e3ff 68%)`,
@@ -13,8 +13,9 @@ module.exports.body = {
 };
 
 module.exports.rightCloud = {
+  position: 'relative',
   zIndex: '-1',
-  marginTop: '-400px',
+  top: '-300px',
   height: '100px',
   width: '500px',
   alignSelf: 'flex-end',
@@ -22,7 +23,9 @@ module.exports.rightCloud = {
 };
 
 module.exports.leftCloud = {
+  position: 'relative',
   zIndex: '-1',
+  top: '-100px',
   height: '100px',
   width: '500px',
   alignSelf: 'flex-start',


### PR DESCRIPTION
Changed the positioning of the elements from being based on margin to being positioned relatively.  Animation changes now manage the right and left positions accordingly to make animation transitions possible.

**Attempting to fix Issue # 9** 