### PR TITLE
Navbar/mobile landscape portrait

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -74,7 +74,8 @@ class App extends React.Component {
       <div style={{
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center'
+        alignItems: 'center',
+        color: 'black',
       }}>
 
         <Navbar 

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -72,6 +72,8 @@ class App extends React.Component {
     return (
 
       <div style={{
+        margin: 0,
+        width: '100%',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
@@ -115,7 +117,7 @@ class App extends React.Component {
           height: '1000px',
           width: '100%',
           backgroundColor: 'rgba(242, 242, 242, 1.0)',
-          padding: '15px'
+          padding: '15px 0'
 
         }}>
           1000px height block<br/>
@@ -126,7 +128,7 @@ class App extends React.Component {
           height: '1000px',
           width: '100%',
           backgroundColor: 'rgba(236, 236, 236, 1.0)',
-          padding: '15px'
+          padding: '15px 0'
         }}>
           1000px height block<br/>
           Content Will be available soon!

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -72,7 +72,6 @@ class App extends React.Component {
     return (
 
       <div style={{
-        margin: 0,
         width: '100%',
         display: 'flex',
         flexDirection: 'column',

--- a/client/components/Navigation/Dropdown/CurrentSelection.jsx
+++ b/client/components/Navigation/Dropdown/CurrentSelection.jsx
@@ -22,11 +22,17 @@ class CurrentSelection extends React.Component {
 
   render() {
 
-    const { yOffset, targets, dropdownToggle } = this.props;
+    const { yOffset, targets, dropdownToggle, orientationFlag } = this.props;
 
     return (
 
-      <div style={applyStyles(style.currentSelection, dropdownToggle && style.currentSelection_pressed)}>
+      <div style={
+        applyStyles(
+          style.currentSelection,
+          dropdownToggle && style.currentSelection_pressed,
+          orientationFlag && style.currentSelection_mobile
+        )
+      }>
         {
           this.displayCurrentSection(yOffset, targets)
         }

--- a/client/components/Navigation/Dropdown/Link.jsx
+++ b/client/components/Navigation/Dropdown/Link.jsx
@@ -16,14 +16,16 @@ class Link extends React.Component {
   render() {
 
     const { hovered } = this.state;
-    const { dropdownToggle, name, onClick } = this.props;
+    const { name, dropdownToggle, orientationFlag, onClick } = this.props;
 
     return (
 
       <div
         style={
           applyStyles(
-            style.link_collapsed, dropdownToggle && style.link_expanded,
+            style.link_collapsed,
+            dropdownToggle && style.link_expanded,
+            (dropdownToggle && orientationFlag) && style.link_expanded_mobile,
             hovered && style.link_hovered,
           )
         }

--- a/client/components/Navigation/Dropdown/Link.jsx
+++ b/client/components/Navigation/Dropdown/Link.jsx
@@ -21,7 +21,12 @@ class Link extends React.Component {
     return (
 
       <div
-        style={applyStyles(style.link_collapsed, dropdownToggle && style.link_expanded, hovered && {backgroundColor: 'rgb(242, 242, 242)'})}
+        style={
+          applyStyles(
+            style.link_collapsed, dropdownToggle && style.link_expanded,
+            hovered && style.link_hovered,
+          )
+        }
         onMouseEnter={dropdownToggle ? () => {this.setState({hovered: true})} : () => {} }
         onMouseLeave={dropdownToggle ? () => {this.setState({hovered: false})} : () => {} }
         onClick={this.props.onClick}

--- a/client/components/Navigation/Dropdown/index.jsx
+++ b/client/components/Navigation/Dropdown/index.jsx
@@ -58,7 +58,8 @@ class Dropdown extends React.Component {
         <div style={
           applyStyles(
             style.dropdownBody_collapsed,
-            dropdownToggle && style.dropdownBody_expanded
+            dropdownToggle && style.dropdownBody_expanded,
+            (dropdownToggle && orientationFlag) && style.dropdownBody_mobile
           )
         }>
 
@@ -70,16 +71,19 @@ class Dropdown extends React.Component {
             <Link 
               name={'Resume'}
               dropdownToggle={dropdownToggle}
+              orientationFlag={orientationFlag}
               onClick={animationChooser(yOffset, 442, calculateDistanceToTarget, scrollEffects)}
             />
             <Link 
               name={'Projects'}
               dropdownToggle={dropdownToggle}
+              orientationFlag={orientationFlag}
               onClick={animationChooser(yOffset, 928, calculateDistanceToTarget, scrollEffects)}
             />
             <Link 
               name={'Blog'}
               dropdownToggle={dropdownToggle}
+              orientationFlag={orientationFlag}
               onClick={animationChooser(yOffset, 1960, calculateDistanceToTarget, scrollEffects)}
             />
           </div>

--- a/client/components/Navigation/Dropdown/index.jsx
+++ b/client/components/Navigation/Dropdown/index.jsx
@@ -33,19 +33,40 @@ class Dropdown extends React.Component {
   render() {
 
     const { dropdownToggle } = this.state;
-    const { yOffset, targets } = this.props;
+    const { yOffset, targets, orientationFlag } = this.props;
 
     return (
 
-      <div style={applyStyles(style.button, dropdownToggle && style.button_pressed)}
+      <div 
         onClick={() => { this.toggleDropdown(dropdownToggle); }}
+        style={
+          applyStyles(
+            style.buttonBody,
+            dropdownToggle && style.button_pressed,
+            orientationFlag && style.buttonBody_mobile
+          )
+        }
       >
  
-        <CurrentSelection yOffset={yOffset} targets={targets} dropdownToggle={dropdownToggle} />
+        <CurrentSelection 
+          yOffset={yOffset}
+          targets={targets}
+          dropdownToggle={dropdownToggle}
+          orientationFlag={orientationFlag}
+        />
 
-        <div style={applyStyles(style.dropdownBody_collapsed, dropdownToggle && style.dropdownBody_expanded)}>
+        <div style={
+          applyStyles(
+            style.dropdownBody_collapsed,
+            dropdownToggle && style.dropdownBody_expanded
+          )
+        }>
 
-          <div style={applyStyles(style.linkContainer_collapsed, dropdownToggle && style.linkContainer_collapsed)}>
+          <div style={
+            applyStyles(
+              style.linkContainer,
+            )
+          }>
             <Link 
               name={'Resume'}
               dropdownToggle={dropdownToggle}

--- a/client/components/Navigation/Dropdown/style.js
+++ b/client/components/Navigation/Dropdown/style.js
@@ -9,12 +9,13 @@ module.exports.buttonBody = {
   alignItems: 'center',
   borderWidth: '2px',
   borderRadius: '2px',
-  WebkitTransition: '0.1s'
+  WebkitTransition: '0.2s'
 };
 
 module.exports.buttonBody_mobile = {
   width: '200px',
 };
+
 
 module.exports.currentSelection = {
   height: '50px',
@@ -30,14 +31,17 @@ module.exports.currentSelection = {
 };
 
 module.exports.currentSelection_mobile = {
-  height: '100px'
+  height: '100px',
+  fontSize: '32px'
 };
+
 
 module.exports.currentSelection_pressed= {
   color: 'rgba(44, 53, 58, 1.0)',
   boxShadow: 'inset 0 4px 8px 4px rgba(0, 0, 0, 0.2)',
   background: 'linear-gradient(to bottom, #59a9f4 17%, #b9dff8 83%)'
 };
+
 
 module.exports.dropdownBody_collapsed = {
   display: 'hidden',
@@ -54,6 +58,11 @@ module.exports.dropdownBody_expanded = {
   height: '225px'
 };
 
+module.exports.dropdownBody_mobile = {
+  height: '300px'
+};
+
+
 module.exports.linkContainer = {
   display: 'hidden',
   height: '0px',
@@ -63,6 +72,7 @@ module.exports.linkContainer = {
   justifyContent: 'center',
   WebkitTransition: '0.2s'
 };
+
 
 module.exports.link_collapsed = {
   display: 'hidden',

--- a/client/components/Navigation/Dropdown/style.js
+++ b/client/components/Navigation/Dropdown/style.js
@@ -76,7 +76,9 @@ module.exports.link_expanded = {
   width: '100%'
 };
 
-
+module.exports.link_hovered = {
+  backgroundColor: 'rgb(242, 242, 242)'
+};
 
 
 

--- a/client/components/Navigation/Dropdown/style.js
+++ b/client/components/Navigation/Dropdown/style.js
@@ -1,4 +1,4 @@
-module.exports.button = {
+module.exports.buttonBody = {
   alignSelf: 'flex-start',
   marginRight: '50px',
   marginTop: '10px',
@@ -12,6 +12,10 @@ module.exports.button = {
   WebkitTransition: '0.1s'
 };
 
+module.exports.buttonBody_mobile = {
+  width: '200px',
+};
+
 module.exports.currentSelection = {
   height: '50px',
   width: '100%',
@@ -23,6 +27,10 @@ module.exports.currentSelection = {
   background: 'linear-gradient(to bottom, #007ac1 17%, #44aaee 83%)',
   boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.2)',
   WebkitTransition: '0.1s'
+};
+
+module.exports.currentSelection_mobile = {
+  height: '100px'
 };
 
 module.exports.currentSelection_pressed= {
@@ -46,7 +54,7 @@ module.exports.dropdownBody_expanded = {
   height: '225px'
 };
 
-module.exports.linkContainer_collapsed = {
+module.exports.linkContainer = {
   display: 'hidden',
   height: '0px',
   width: '100%',
@@ -54,11 +62,6 @@ module.exports.linkContainer_collapsed = {
   alignItems: 'center',
   justifyContent: 'center',
   WebkitTransition: '0.2s'
-};
-
-module.exports.linkContainer_expanded = {
-  display: 'flex',
-  height: '225px'
 };
 
 module.exports.link_collapsed = {

--- a/client/components/Navigation/Dropdown/style.js
+++ b/client/components/Navigation/Dropdown/style.js
@@ -13,6 +13,7 @@ module.exports.buttonBody = {
 };
 
 module.exports.buttonBody_mobile = {
+  marginTop: '15px',
   width: '200px',
 };
 
@@ -87,6 +88,11 @@ module.exports.link_expanded = {
   display: 'flex',
   height: '75px',
   width: '100%'
+};
+
+module.exports.link_expanded_mobile = {
+  height: '100px',
+  fontSize: '32px'
 };
 
 module.exports.link_hovered = {

--- a/client/components/Navigation/Title/index.jsx
+++ b/client/components/Navigation/Title/index.jsx
@@ -1,18 +1,36 @@
 import React from 'react';
 
+import applyStyles from '../../../helpers/applyStyles';
+
 import style from './style';
 
-const Title = (props) => (
+const Title = (props) => {
 
-  <span 
-    onClick={() => {props.onClick()}}
-    style={style.title_left}
-  >
-    COS
-    <span style={style.title_right}>-BYTES</span>
-  </span>
+  const { mobileToggle, orientationFlag } = props;
 
-);
+  return (
+    <span
+      onClick={() => {props.onClick()}}
+      style={
+        applyStyles(
+          style.title,
+          (mobileToggle && orientationFlag) && style.title_mobile
+        )
+      }
+    >
+      COS
+      <span 
+        style={
+          applyStyles(
+            style.title_blue
+          )
+        }
+      >
+        -BYTES
+      </span>
+    </span>
+  )
+};
 
 export default Title;
 

--- a/client/components/Navigation/Title/style.js
+++ b/client/components/Navigation/Title/style.js
@@ -1,11 +1,17 @@
-module.exports.title_left = {
+module.exports.title = {
   cursor: 'pointer',
   marginLeft: '50px',
   padding: '0 6px',
   fontSize: '30px',
-  color: 'rgba(41, 67, 78, 1.0)'
+  color: 'rgba(41, 67, 78, 1.0)',
+  WebkitTransition: '0.1s'
 };
 
-module.exports.title_right = {
+module.exports.title_mobile = {
+  fontSize: '48px'
+};
+
+
+module.exports.title_blue = {
   color: 'rgba(0, 122, 193, 1.0)'
 };

--- a/client/components/Navigation/index.jsx
+++ b/client/components/Navigation/index.jsx
@@ -29,7 +29,7 @@ class Navbar extends React.Component {
         }]);
       case 'sharp':
         return ([
-          yOffset >= 423 && {WebkitTransition: 'ease-in 0.2s', backgroundColor: `rgba(250, 250, 250, ${(percentScrolled / 10).toFixed(1)})`}, 
+          yOffset >= 423 && {WebkitTransition: '0.1s', backgroundColor: `rgba(250, 250, 250, ${(percentScrolled / 10).toFixed(1)})`}, 
           yOffset >= 425 && {boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.4)'}
         ]);
     }

--- a/client/components/Navigation/index.jsx
+++ b/client/components/Navigation/index.jsx
@@ -46,7 +46,11 @@ class Navbar extends React.Component {
 
       <div style={applyStyles(style.main, ...this.renderOption(animationOption), (mobileToggle && orientationFlag) && style.main_mobile)}>
 
-        <Title onClick={yOffset === 0 ? () => {} : animationChooser(yOffset, 0, calculateDistanceToTarget, scrollEffects)}/>
+        <Title
+          mobileToggle={mobileToggle}
+          orientationFlag={orientationFlag}
+          onClick={yOffset === 0 ? () => {} : animationChooser(yOffset, 0, calculateDistanceToTarget, scrollEffects)}
+        />
         
         {
           mobileToggle

--- a/client/components/Navigation/index.jsx
+++ b/client/components/Navigation/index.jsx
@@ -37,18 +37,28 @@ class Navbar extends React.Component {
 
   render() {
 
-    const { percentScrolled, screenWidth, yOffset, animationOption, targets } = this.props;
-    let mobileToggle = screenWidth < 1000;
+    const { percentScrolled, screenWidth, screenHeight, yOffset, animationOption, targets } = this.props;
+
+    let mobileToggle = screenWidth < 1000; // True: Mobile View, False: Desktop View
+    let orientationFlag = screenWidth < screenHeight; // True: Portrait, False: Landscaped
 
     return (
 
-      <div style={applyStyles(style.main, ...this.renderOption(animationOption))}>
+      <div style={applyStyles(style.main, ...this.renderOption(animationOption), (mobileToggle && orientationFlag) && style.main_mobile)}>
 
         <Title onClick={yOffset === 0 ? () => {} : animationChooser(yOffset, 0, calculateDistanceToTarget, scrollEffects)}/>
+        
         {
           mobileToggle
-            ? <Dropdown yOffset={yOffset} targets={targets} />
-            : <LinkRow yOffset={yOffset}/>
+            ? <Dropdown 
+                yOffset={yOffset}
+                targets={targets}
+                orientationFlag={orientationFlag}
+              />
+            : <LinkRow 
+                yOffset={yOffset}
+                orientationFlag={orientationFlag}
+              />
         }
 
       </div>

--- a/client/components/Navigation/style.js
+++ b/client/components/Navigation/style.js
@@ -6,7 +6,7 @@ module.exports.main = {
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',
-  WebkitTransition: 'linear 0.1s',
+  WebkitTransition: '0.1s',
   zIndex: '1'
 };
 

--- a/client/components/Navigation/style.js
+++ b/client/components/Navigation/style.js
@@ -11,5 +11,5 @@ module.exports.main = {
 };
 
 module.exports.main_mobile = {
-  height: '120px',
+  height: '130px',
 };

--- a/client/components/Navigation/style.js
+++ b/client/components/Navigation/style.js
@@ -9,3 +9,7 @@ module.exports.main = {
   WebkitTransition: 'linear 0.1s',
   zIndex: '1'
 };
+
+module.exports.main_mobile = {
+  height: '100px',
+};

--- a/client/components/Navigation/style.js
+++ b/client/components/Navigation/style.js
@@ -11,5 +11,5 @@ module.exports.main = {
 };
 
 module.exports.main_mobile = {
-  height: '100px',
+  height: '120px',
 };

--- a/public/index.html
+++ b/public/index.html
@@ -6,10 +6,11 @@
     <style>
       html{position: absolute; width: 100%;}
       body{margin: 0; background-color: rgba(255, 255, 255, 1.0); font-family: 'Roboto', sans-serif; width: 100%;}
+      #app{color: white;}
     </style>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">This is the digital portfolio for Thomas Cosby.  This website features his resume, collection of his projects, and his personal blog.</div>
     <script src="/bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
# **In This Pull Request:**


## **Mobile Navigation**

Before this branch, the mobile navbar did not scale as the device width changed between landscape and portrait.  In the portrait view, the navbar and all of it's elements were showing up very small and very hard to press.  This PR addresses this issue.

### **Solution:**

To accomplish this feature, I added a flag (represented by a boolean) that would be change depending on if the width of the viewport is less than the height of the viewport.  

If the value is true, that means we're in portrait mode.  This flag allows me to take advantage of the applyStyles function with && operator controlled object extension to allow for transitions in our CSS in JS.

When the screen size changes, I have an event listener on the DOM that will _setState_ of the current viewport _height_ and _width_ in the ancestor most component.  This allows the transitions to re-render the appropriate components that depend on these two values.


## **Bug Fixes**

- The placeholder containers for the project and blog content had 10px of padding all the way around, but was causing a thin strip of white background to appear on the right side of the screen.  At first I thought this was a feature of IOS or something, but turned out I had a hidden bug.

