### PR TITLE
Fix/remove user select pictures

### DIFF
--- a/client/components/Jumbotron/style.js
+++ b/client/components/Jumbotron/style.js
@@ -28,6 +28,11 @@ module.exports.rightCloud = {
   height: '100px',
   width: '500px',
   alignSelf: 'flex-end',
+  WebkitUserSelect: 'none',
+  khtmlUserSelect: 'none',
+  MozUserSelect: 'none',
+  OUserSelect: 'none',
+  userSelect: 'none',
 };
 
 module.exports.rightCloud_mobile_portrait = {
@@ -42,6 +47,11 @@ module.exports.leftCloud = {
   height: '100px',
   width: '500px',
   alignSelf: 'flex-start',
+  WebkitUserSelect: 'none',
+  khtmlUserSelect: 'none',
+  MozUserSelect: 'none',
+  OUserSelect: 'none',
+  userSelect: 'none',
 };
 
 module.exports.leftCloud_mobile_portrait = {

--- a/client/components/Navigation/Title/style.js
+++ b/client/components/Navigation/Title/style.js
@@ -4,6 +4,11 @@ module.exports.title = {
   padding: '21.5px 21.5px 21.5px 0',
   fontSize: '30px',
   color: 'rgba(41, 67, 78, 1.0)',
+  WebkitUserSelect: 'none',
+  khtmlUserSelect: 'none',
+  MozUserSelect: 'none',
+  OUserSelect: 'none',
+  userSelect: 'none',
   WebkitTransition: '0.1s'
 };
 


### PR DESCRIPTION
## **In This Pull Request:**


I learned how to prevent the user-selection of certain elements in the DOM, so I attempted to apply it to the images but it was unsuccessful.  


### **No-selects**

' WebkitUserSelect: 'none',
  khtmlUserSelect: 'none',
  MozUserSelect: 'none',
  OUserSelect: 'none',
  userSelect: 'none', '

This is the code that you will need to add a no-select to certain text components.