### PR TITLE
Feature/resume component mvp

### DIFF
--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Experience/jobs.js
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Experience/jobs.js
@@ -7,7 +7,7 @@ module.exports.hackReactor = {
   image: 'https://static1.squarespace.com/static/ta/522a22cbe4b04681b0bff826/3098/assets/images/logo/hack-reactor-logo.png',
   employmentRange: {
     start: 'Sept. 2017',
-    end: 'Present'
+    end: 'Jan. 2018'
   },
   title: 'Software Engineering Teaching Assistant'
 };

--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Links/Button.jsx
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Links/Button.jsx
@@ -11,6 +11,7 @@ class Button extends React.Component {
       clicked: false
     };
     this.handleClick = this.handleClick.bind(this);
+    this.renderLabel = this.renderLabel.bind(this);
   }
 
   handleClick() {
@@ -20,6 +21,17 @@ class Button extends React.Component {
         this.setState({clicked: false}, onClick)
       }, 100);
     });
+  }
+
+  renderLabel(labelType) {
+    let { hovered } = this.state;
+    let { label = '', applyStyles } = this.props; // initialize label to empty string if none passed in
+    switch(labelType) {
+      case 'image': 
+        return (<img style={applyStyles(hovered && style.buttonLabel_hovered)} src={label} />);
+      default:
+        return label 
+    }
   }
 
   componentDidMount() {
@@ -33,11 +45,12 @@ class Button extends React.Component {
   render() {
 
     const { loaded, hovered, clicked } = this.state;
-    const { label, hoverColor = {backgroundColor: 'rgba(0, 122, 193, 1.0)'}, onClick, applyStyles } = this.props;
-
-    let labelTrigger = typeof label === 'object';
-
-    console.log(label);
+    const { 
+      labelType,
+      hoverColor = {backgroundColor: 'rgba(0, 122, 193, 1.0)'}, // initialize to blue hover color if none passed in
+      onClick,
+      applyStyles
+    } = this.props;
 
     return (
 
@@ -54,9 +67,7 @@ class Button extends React.Component {
           )
         }
       >
-        {
-          label
-        }
+        {this.renderLabel(labelType)}
       </div>
 
     );

--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Links/Button.jsx
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Links/Button.jsx
@@ -30,7 +30,7 @@ class Button extends React.Component {
       case 'image': 
         return (<img style={applyStyles(hovered && style.buttonLabel_hovered)} src={label} />);
       default:
-        return label 
+        return label;
     }
   }
 

--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Links/Button.jsx
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Links/Button.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import style from './style';
+
+class Button extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loaded: false,
+      hovered: false,
+      clicked: false
+    };
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    let { onClick } = this.props;
+    this.setState({clicked: true}, () => {
+      setTimeout(() => {
+        this.setState({clicked: false}, onClick)
+      }, 100);
+    });
+  }
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({
+        loaded: true
+      }); 
+    }, 500);
+  }
+
+  render() {
+
+    const { loaded, hovered, clicked } = this.state;
+    const { label, hoverColor = {backgroundColor: 'rgba(0, 122, 193, 1.0)'}, onClick, applyStyles } = this.props;
+
+    let labelTrigger = typeof label === 'object';
+
+    console.log(label);
+
+    return (
+
+      <div 
+        onClick={this.handleClick}
+        onMouseEnter={() => { this.setState({hovered: true}); }}
+        onMouseLeave={() => { this.setState({hovered: false}); }}
+        style={
+          applyStyles(
+            style.button,
+            loaded && style.button_loaded,
+            hovered && Object.assign(style.button_hovered, hoverColor),
+            clicked && style.button_clicked
+          )
+        }
+      >
+        {
+          label
+        }
+      </div>
+
+    );
+
+  }
+}
+
+export default Button;

--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Links/index.jsx
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Links/index.jsx
@@ -58,26 +58,13 @@ class LinksSlide extends React.Component {
 
         </div>
 
-        <div style={{
-          height: '100%',
-          width: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}>
+        <div style={style.resumeLinkBody}>
 
-          <div style={{
-            height: '100px',
-            width: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}>
+          <div style={style.resumeDescription}>
             <center>If you would like to view or download my resume, click below!</center>
           </div>
 
-          <a href={'https://s3-us-west-1.amazonaws.com/cos-bytes.com/resume.pdf'} target='_blank'>
+          <a style={style.textLabelFormat} href={'https://s3-us-west-1.amazonaws.com/cos-bytes.com/resume.pdf'} target='_blank'>
             <Button 
               label={'Resume'}
               hoverColor={{backgroundColor: 'rgba(0, 122, 193, 1.0)'}}

--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Links/index.jsx
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Links/index.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import Button from './Button.jsx';
+
 import style from './style';
 
 class LinksSlide extends React.Component {
@@ -31,7 +33,61 @@ class LinksSlide extends React.Component {
           loaded && style.body_loaded
         )
       }>
-        <center>This is the Links Slide.  This slide will display when the Links Tab is clicked</center>
+
+        <div style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'space-evenly',
+        }}>
+
+          <Button 
+            label={'https://s3-us-west-1.amazonaws.com/cos-bytes.com/github_logo.png'}
+            labelType={'image'}
+            hoverColor={{backgroundColor: 'rgb(64, 64, 64)'}}
+            onClick={() => { console.log('Github button click'); }}
+            applyStyles={applyStyles}
+          />
+
+          <Button 
+            label={'Linkedin'}
+            hoverColor={{backgroundColor: 'rgba(0, 122, 193, 1.0)'}}
+            onClick={() => { console.log('Linkedin button click'); }}
+            applyStyles={applyStyles}
+          />
+
+        </div>
+
+        <div style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}>
+
+          <div style={{
+            height: '100px',
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            <center>If you would like to view or download my resume, click below!</center>
+          </div>
+
+          <Button 
+            label={'Resume'}
+            hoverColor={{backgroundColor: 'rgba(0, 122, 193, 1.0)'}}
+            onClick={() => { console.log('Resume button click'); }}
+            applyStyles={applyStyles}
+          />
+
+        </div>
+
       </div>
 
     ); 
@@ -40,3 +96,5 @@ class LinksSlide extends React.Component {
 }
 
 export default LinksSlide;
+
+// <center><a href="https://s3-us-west-1.amazonaws.com/cos-bytes.com/resume.pdf" target="_blank">Link</a></center>

--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Links/index.jsx
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Links/index.jsx
@@ -34,29 +34,27 @@ class LinksSlide extends React.Component {
         )
       }>
 
-        <div style={{
-          height: '100%',
-          width: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'space-evenly',
-        }}>
+        <div style={style.externalLinksBody}>
 
-          <Button 
-            label={'https://s3-us-west-1.amazonaws.com/cos-bytes.com/github_logo.png'}
-            labelType={'image'}
-            hoverColor={{backgroundColor: 'rgb(64, 64, 64)'}}
-            onClick={() => { console.log('Github button click'); }}
-            applyStyles={applyStyles}
-          />
+          <a href={'https://github.com/irbab00n'} target='_blank'>
+            <Button 
+              label={'https://s3-us-west-1.amazonaws.com/cos-bytes.com/github_logo.png'}
+              labelType={'image'}
+              hoverColor={{backgroundColor: 'rgb(64, 64, 64)'}}
+              onClick={() => { console.log('Github button click'); }}
+              applyStyles={applyStyles}
+            />
+          </a>
 
-          <Button 
-            label={'Linkedin'}
-            hoverColor={{backgroundColor: 'rgba(0, 122, 193, 1.0)'}}
-            onClick={() => { console.log('Linkedin button click'); }}
-            applyStyles={applyStyles}
-          />
+          <a href={'https://www.linkedin.com/in/cosbyts/'} target='_blank'>
+            <Button 
+              label={'https://s3-us-west-1.amazonaws.com/cos-bytes.com/linkedin_logo.png'}
+              labelType={'image'}
+              hoverColor={{backgroundColor: 'rgba(0, 122, 193, 1.0)'}}
+              onClick={() => { console.log('Linkedin button click'); }}
+              applyStyles={applyStyles}
+            />
+          </a>
 
         </div>
 
@@ -79,12 +77,14 @@ class LinksSlide extends React.Component {
             <center>If you would like to view or download my resume, click below!</center>
           </div>
 
-          <Button 
-            label={'Resume'}
-            hoverColor={{backgroundColor: 'rgba(0, 122, 193, 1.0)'}}
-            onClick={() => { console.log('Resume button click'); }}
-            applyStyles={applyStyles}
-          />
+          <a href={'https://s3-us-west-1.amazonaws.com/cos-bytes.com/resume.pdf'} target='_blank'>
+            <Button 
+              label={'Resume'}
+              hoverColor={{backgroundColor: 'rgba(0, 122, 193, 1.0)'}}
+              onClick={() => { console.log('Resume button click'); }}
+              applyStyles={applyStyles}
+            />
+          </a>
 
         </div>
 
@@ -97,4 +97,10 @@ class LinksSlide extends React.Component {
 
 export default LinksSlide;
 
-// <center><a href="https://s3-us-west-1.amazonaws.com/cos-bytes.com/resume.pdf" target="_blank">Link</a></center>
+
+
+
+
+
+
+

--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Links/style.js
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Links/style.js
@@ -14,3 +14,39 @@ module.exports.body = {
 module.exports.body_loaded = {
   right: '0px'
 };
+
+
+module.exports.button = {
+  cursor: 'pointer',
+  height: '50px',
+  width: '375px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: '#ffffff',
+  borderWidth: '2px',
+  borderRadius: '2px',
+  borderColor: '#f2f2f2',
+  fontSize: '14px',
+  WebkitUserSelect: 'none',
+  khtmlUserSelect: 'none',
+  MozUserSelect: 'none',
+  OUserSelect: 'none',
+  userSelect: 'none',
+  WebkitTransition: '0.2s'
+};
+
+module.exports.button_loaded = {
+  boxShadow: '0 2px 6px 0 rgba(0, 0, 0, 0.3)'
+};
+
+module.exports.button_hovered = {
+  boxShadow: '0 2px 6px 0 rgba(0, 0, 0, 0.6)',
+  // backgroundColor: 'rgba(0, 122, 193, 1.0)',
+  color: '#f2f2f2'
+};
+
+module.exports.button_clicked = {
+  boxShadow: '0 0 0 0 rgba(0, 0, 0, 0.0)',
+  backgroundColor: 'rgba(0, 60, 100, 1.0)',
+};

--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Links/style.js
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Links/style.js
@@ -1,3 +1,5 @@
+/* Main Body styles */
+
 module.exports.body = {
   position: 'relative',
   right: '-1000px',
@@ -7,7 +9,7 @@ module.exports.body = {
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'space-evenly',
-  backgroundColor: 'rgb(250, 250, 250)',
+  backgroundColor: 'rgba(250, 250, 250, 1.0)',
   WebkitTransition: '0.2s'
 };
 
@@ -15,7 +17,7 @@ module.exports.body_loaded = {
   right: '0px'
 };
 
-
+/* Link Body styles */
 
 module.exports.externalLinksBody = {
   height: '100%',
@@ -26,9 +28,29 @@ module.exports.externalLinksBody = {
   justifyContent: 'space-evenly',
 };
 
-module.exports.resumeL
+module.exports.resumeLinkBody = {
+  height: '100%',
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
 
+module.exports.resumeDescription = {
+  height: '100px',
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
 
+module.exports.textLabelFormat = {
+  textDecoration: 'none',
+  color: 'black'
+};
+
+/* Button styles */
 
 module.exports.button = {
   cursor: 'pointer',
@@ -37,7 +59,7 @@ module.exports.button = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  backgroundColor: '#ffffff',
+  backgroundColor: 'rgba(250, 250, 250, 1.0)',
   borderWidth: '2px',
   borderRadius: '2px',
   borderColor: '#f2f2f2',

--- a/client/components/Resume/DesktopView/DisplayBox/Slides/Links/style.js
+++ b/client/components/Resume/DesktopView/DisplayBox/Slides/Links/style.js
@@ -16,6 +16,20 @@ module.exports.body_loaded = {
 };
 
 
+
+module.exports.externalLinksBody = {
+  height: '100%',
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'space-evenly',
+};
+
+module.exports.resumeL
+
+
+
 module.exports.button = {
   cursor: 'pointer',
   height: '50px',
@@ -44,6 +58,15 @@ module.exports.button_hovered = {
   boxShadow: '0 2px 6px 0 rgba(0, 0, 0, 0.6)',
   // backgroundColor: 'rgba(0, 122, 193, 1.0)',
   color: '#f2f2f2'
+};
+
+module.exports.buttonLabel = {
+  WebkitTransition: '0.2s'
+};
+
+module.exports.buttonLabel_hovered = {
+  WebkitFilter: 'invert(1)',
+  filter: 'invert(1)',
 };
 
 module.exports.button_clicked = {


### PR DESCRIPTION
## **In this Pull Request:**

This pull request marks the completion of the Resume component of my portfolio website.  Each resume slide is unique and offers a simple but effective user experience.

### **Links Slide**

The link slide is now complete and now features 3 links: Github, Linkedin, and my resume.

- Clicking buttons will open up new a new tab every time they are pressed

_Currently, this is accomplished by wrapping the button in an 'a' HTML tag.  I tried working the tag into the Button component itself, but for some reason only 1 button click would work, then the rest would fail until I re-mounted the component.  Rather than spend a lengthy amount of time trying to chase down the bug, I decided to omit the 'a' tag from the Button entirely._

- Button images invert colors upon hovering

_While this approach to applying an on-hover effect to the images to keep enough contrast to not lose the label image, it will have weird side-effects depending on the primary color before inversion.  E.g., the Linkedin image has a blue square that will invert to a bright orange, while the text converts from black to white.  Thankfully, in this case, orange, blue, and white go together well enough that this doesn't come across as visually distracting._

- Buttons can support both image labels or text labels

_If a label isn't supplied as a prop to the button, the component initializes the label as an empty string, which produces a blank label on the button._
