### PR TITLE
Added pre-caching for project images

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Precache from './components/Precache/index.jsx';
 import Navbar from './components/Navigation/index.jsx';
 import Jumbotron from './components/Jumbotron/index.jsx';
 import Resume from './components/Resume/index.jsx';
@@ -84,6 +85,10 @@ class App extends React.Component {
         alignItems: 'center',
         color: 'black',
       }}>
+
+        <Precache image='https://s3-us-west-1.amazonaws.com/cos-bytes.com/vagabondly_fleshed.jpg' />
+        <Precache image='https://s3-us-west-1.amazonaws.com/cos-bytes.com/vagabondly_skeleton.jpg' />
+        <Precache image='https://s3-us-west-1.amazonaws.com/cos-bytes.com/vagabondly_trips.jpg' />
 
         <Navbar 
           screenWidth={screenWidth}

--- a/client/components/Precache/index.jsx
+++ b/client/components/Precache/index.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Precache = (props) => {
+  return (
+    <span style={{background: `url(${props.image})`}} hidden></span>
+  );
+};
+
+export default Precache;

--- a/client/components/Projects/index.jsx
+++ b/client/components/Projects/index.jsx
@@ -9,8 +9,6 @@ class Projects extends React.Component {
 
   render() {
 
-    const { applyStyles } = this.props;
-
     return (
 
       <DesktopView />

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/irbab00n/portfolio#readme",
   "dependencies": {
-    "applystyles": "^1.0.0",
+    "applystyles": "3.0.0",
     "axios": "^0.17.1",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
## **In This Pull Request**

I have implemented a way for me to pre-cache images that will be used to store images in browser memory earlier on.  This has helped reduce a small lag spike in the animations attempting to request the photo, then display it.   Now that it's looking for resources stored in the cache, it has sped up the process quite a lot.