### PR TITLE
Added tap listener on toggleStrip

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -48,6 +48,7 @@ class App extends React.Component {
     this.setState({screenWidth: window.innerWidth, screenHeight: window.innerHeight})
   }
 
+
   render() {
 
     const { screenWidth, screenHeight, percentScrolled } = this.state;

--- a/client/components/Projects/Project/Carousel/style.js
+++ b/client/components/Projects/Project/Carousel/style.js
@@ -18,7 +18,7 @@ module.exports.carousel_body_mobile_portrait = {
 
 
 module.exports.carousel_body_collapsed = {
-  width: '60%',
+  width: '70%',
   height: '100%'
 };
 

--- a/client/components/Projects/Project/TitleBox/Description/index.jsx
+++ b/client/components/Projects/Project/TitleBox/Description/index.jsx
@@ -21,6 +21,12 @@ export default class Description extends React.Component {
     reel();
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.collapsed !== this.props.collapsed || nextProps.orientationFlag !== this.props.orientationFlag) {
+      this.fadeInAnimation();
+    }
+  }
+
   componentDidMount() {
     this.fadeInAnimation();
   }

--- a/client/components/Projects/Project/TitleBox/Title/index.jsx
+++ b/client/components/Projects/Project/TitleBox/Title/index.jsx
@@ -59,7 +59,7 @@ export default class Title extends React.Component {
         <div
           style={
             apply(
-              {marginTop: '2%', display: 'flex', flexDirection: 'column', alignItems: 'center'},
+              {marginTop: '1%', display: 'flex', flexDirection: 'column', alignItems: 'center'},
               mobileToggle && {marginBottom: '1%', flexDirection: 'row'},
               orientationFlag && {marginTop: '2%', flexDirection: 'column'},
               collapsed && {flexDirection: 'column'},
@@ -98,9 +98,10 @@ export default class Title extends React.Component {
 
 
           <div
+            id="project-links"
             style={
               apply(
-                {marginTop: '4%', width: '100%', display: 'flex', flexDirection: 'column'},
+                {marginTop: '2%', width: '100%', display: 'flex', flexDirection: 'column'},
                 mobileToggle && {marginTop: '0%'},
                 orientationFlag && {marginTop: '4%'},
                 (collapsed && mobileToggle) && {marginTop: '4%'}
@@ -123,7 +124,7 @@ export default class Title extends React.Component {
                 id="link-container"
                 style={
                   apply(
-                    {marginLeft: '5%', fontSize: '80%', color: 'rgba(35, 35, 135, 1.0)', WebkitTransition: '0.5s', textDecoration: 'none', display: 'flex', flexDirection: 'row', alignItems: 'center'},
+                    {marginLeft: '5%', fontSize: '70%', color: 'rgba(35, 35, 135, 1.0)', WebkitTransition: '0.5s', textDecoration: 'none', display: 'flex', flexDirection: 'row', alignItems: 'center'},
                     mobileToggle && {fontSize: '100%'},
                     orientationFlag && {fontSize: '160%'},
                     collapsed && {fontSize: '80%'},
@@ -162,7 +163,7 @@ export default class Title extends React.Component {
                 id="link-container"
                 style={
                   apply(
-                    {marginLeft: '5%', fontSize: '80%', color: 'rgba(35, 35, 135, 1.0)', WebkitTransition: '0.5s', textDecoration: 'none', display: 'flex', flexDirection: 'row', alignItems: 'center'},
+                    {marginLeft: '5%', fontSize: '70%', color: 'rgba(35, 35, 135, 1.0)', WebkitTransition: '0.5s', textDecoration: 'none', display: 'flex', flexDirection: 'row', alignItems: 'center'},
                     mobileToggle && {fontSize: '100%'},
                     orientationFlag && {fontSize: '160%'},
                     collapsed && {fontSize: '80%'},
@@ -227,8 +228,8 @@ export default class Title extends React.Component {
           id="contributor-list"
           style={
             apply(
-              {margin: '2% 0 2% 5%', width: '90%', WebkitTransition: '0.5s'},
-              mobileToggle && {margin: '0 auto'},
+              {margin: '2% 5%', paddingLeft: '5%', WebkitTransition: '0.5s'},
+              mobileToggle && {},
               orientationFlag && {margin: '2% 0 2% 5%'},
               collapsed && {margin: '2% 0 2% 5%'}
             )
@@ -241,11 +242,11 @@ export default class Title extends React.Component {
                   key={`contrib-${index}`}
                   style={
                     apply(
-                      {fontSize: '70%', color: 'rgba(35, 35, 35, 1.0)', WebkitTransition: '0.5s'},
-                      mobileToggle && {margin: '0 1%', color: 'rgba(35, 35, 35, 1.0)', display: 'inline-block'},
-                      orientationFlag && {fontSize: '160%', display: 'list-item'},
-                      collapsed && {fontSize: '80%'},
-                      (collapsed && mobileToggle) && {fontSize: '80%', display: 'list-item'},
+                      {margin: '0 1%', fontSize: '70%', color: 'rgba(35, 35, 35, 1.0)', WebkitTransition: '0.5s', display: 'inline-block'},
+                      mobileToggle && {color: 'rgba(35, 35, 35, 1.0)', display: 'inline-block'},
+                      orientationFlag && {fontSize: '160%', display: 'block'},
+                      collapsed && {fontSize: '80%', display: 'block'},
+                      (collapsed && mobileToggle) && {fontSize: '80%', display: 'block'},
                       (collapsed && orientationFlag) && {fontSize: '160%'},
                       fadein && {color: 'rgba(35, 35, 35, 0.0)', WebkitTransition: 'none'}
                     )

--- a/client/components/Projects/Project/TitleBox/Title/style.js
+++ b/client/components/Projects/Project/TitleBox/Title/style.js
@@ -3,7 +3,6 @@
 module.exports.title_block = {
   height: '100%',
   width: '40%',
-  minWidth: '40vw',
   display: 'flex',
   flexDirection: 'column',
   backgroundColor: 'rgba(220, 220, 220, 0.4)'
@@ -23,8 +22,8 @@ module.exports.title_block_mobile_portrait = {
 
 module.exports.title_block_collapsed = {
   height: '100%',
-  width: '40%',
-  minWidth: '40vw'
+  width: '100%',
+  minWidth: '30vw'
 };
 
 module.exports.title_block_collapsed_mobile_landscape = {

--- a/client/components/Projects/Project/TitleBox/style.js
+++ b/client/components/Projects/Project/TitleBox/style.js
@@ -27,12 +27,12 @@ module.exports.container_body_collapsed = {
   alignItems: 'center',
   justifyContent: 'center',
   flexDirection: 'row',
-  width: '40%',
+  width: '30%',
   height: '100%',
 };
 
 module.exports.container_body_collapsed_mobile_landscape = {
-
+  width: '40%'
 };
 
 module.exports.container_body_collapsed_mobile_portrait = {

--- a/client/components/Projects/Project/ToggleStrip/index.jsx
+++ b/client/components/Projects/Project/ToggleStrip/index.jsx
@@ -9,15 +9,31 @@ export default class ToggleStrip extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
+    this.handleUserTap = this.handleUserTap.bind(this);
+  }
+
+  componentWillMount() {
+    window.addEventListener('touchstart', this.handleUserTap);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('touchstart', this.handleUserTap);
+  }
+
+  handleUserTap(e) {
+    if (e.target.id === `toggle-strip-${this.props.number}`) {
+      this.props.toggleFunction();
+    }
   }
 
   render() {
 
-    const { mobileToggle, collapsed, toggleFunction } = this.props;
+    const { number, mobileToggle, collapsed, toggleFunction } = this.props;
 
     return (
 
-      <div 
+      <div
+        id={`toggle-strip-${number}`}
         style={
           apply(
             style.list_body_button,
@@ -25,7 +41,7 @@ export default class ToggleStrip extends React.Component {
             collapsed && style.list_body_button_collapsed
           )
         }
-        onClick={toggleFunction}
+        onClick={mobileToggle ? () => {} : toggleFunction}
       >
         <Triangle 
           toggle={collapsed}

--- a/client/components/Projects/Project/index.jsx
+++ b/client/components/Projects/Project/index.jsx
@@ -30,6 +30,7 @@ export default class Project extends React.Component {
     } = this.state;
 
     const {
+      number,
       project,
       screenWidth,
       screenHeight,
@@ -37,6 +38,7 @@ export default class Project extends React.Component {
       orientationFlag,
       yOffset
     } = this.props;
+
 
     return (
 
@@ -55,6 +57,7 @@ export default class Project extends React.Component {
       >
 
         <ToggleStrip
+          number={number}
           mobileToggle={mobileToggle}
           collapsed={collapsed}
           toggleFunction={this.toggleCollapse}

--- a/client/components/Projects/Project/style.js
+++ b/client/components/Projects/Project/style.js
@@ -49,7 +49,7 @@ module.exports.project_container_mobile_landscape = {
 };
 
 module.exports.project_container_mobile_portrait = {
-
+  height: '140vh'
 };
 
 module.exports.project_container_collapsed = {

--- a/client/components/Projects/index.jsx
+++ b/client/components/Projects/index.jsx
@@ -89,6 +89,7 @@ class Projects extends React.Component {
             return (
               <Project 
                 key={`project${index}`}
+                number={index}
                 project={projectsList[key]}
                 screenWidth={screenWidth}
                 screenHeight={screenHeight}


### PR DESCRIPTION
- also, reduced the size of the title block on the desktop view from 40% to 30%.  This allows more room for photos on the carousel, and less white space in the title block